### PR TITLE
fixes #99: Fix context-less messages sorting.

### DIFF
--- a/test_data/example_sort.xml
+++ b/test_data/example_sort.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+    <message>
+        <source>contextLessMessage</source>
+        <location line="456" filename="ui_main.cpp" />
+        <location line="312" filename="ai_main.cpp" />
+        <location line="300" filename="ai_main.cpp" />
+        <location line="10" filename="ui_potato_viewer.cpp" />
+        <comment>An example entry for contextLessMessage</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <context>
+        <name>UiContext</name>
+        <message>
+            <source>Name</source>
+            <location line="456" filename="ui_main.cpp" />
+            <location line="10" filename="ui_potato_viewer.cpp" />
+            <location line="321" filename="ui_main.cpp" />
+            <location line="11" filename="ui_potato_viewer.cpp" />
+            <comment>An example entry for Name</comment>
+            <translation type="unfinished"></translation>
+        </message>
+        <message>
+            <location line="10" filename="ui_potato_viewer.cpp" />
+            <location line="144" filename="ui_main.cpp" />
+            <source>This is just a Sample</source>
+            <translation>Dies ist nur ein Beispiel</translation>
+        </message>
+        <message>
+            <source>Practice more</source>
+            <translation type="unfinished"></translation>
+        </message>
+    </context>
+    <context>
+        <name>CodeContext</name>
+        <message>
+            <source>I am a message in which was written in Code</source>
+            <translation type="unfinished"></translation>
+        </message>
+    </context>
+</TS>

--- a/test_data/example_sort_sorted.xml
+++ b/test_data/example_sort_sorted.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+    <context>
+        <name>CodeContext</name>
+        <message>
+            <source>I am a message in which was written in Code</source>
+            <translation type="unfinished"></translation>
+        </message>
+    </context>
+    <context>
+        <name>UiContext</name>
+        <message>
+            <source>This is just a Sample</source>
+            <translation>
+                Dies ist nur ein Beispiel
+            </translation>
+            <location filename="ui_main.cpp" line="144"></location>
+            <location filename="ui_potato_viewer.cpp" line="10"></location>
+        </message>
+        <message>
+            <source>Name</source>
+            <translation type="unfinished"></translation>
+            <location filename="ui_main.cpp" line="321"></location>
+            <location filename="ui_main.cpp" line="456"></location>
+            <location filename="ui_potato_viewer.cpp" line="10"></location>
+            <location filename="ui_potato_viewer.cpp" line="11"></location>
+            <comment>An example entry for Name</comment>
+        </message>
+        <message>
+            <source>Practice more</source>
+            <translation type="unfinished"></translation>
+        </message>
+    </context>
+    <message>
+        <source>contextLessMessage</source>
+        <translation type="unfinished"></translation>
+        <location filename="ai_main.cpp" line="300"></location>
+        <location filename="ai_main.cpp" line="312"></location>
+        <location filename="ui_main.cpp" line="456"></location>
+        <location filename="ui_potato_viewer.cpp" line="10"></location>
+        <comment>An example entry for contextLessMessage</comment>
+    </message>
+</TS>


### PR DESCRIPTION
* Found as part of making the command line tool more robust, see #21.

### Pull request checklist

- [x] This pull request relates to an existing [issue ticket](https://github.com/mrtryhard/qt-ts-tools/issues). If not, create one.
- [x] [`CHANGELOG.md`](https://github.com/mrtryhard/qt-ts-tools/blob/main/CHANGELOG.md) is updated if relevant. 
- [x] You are aware that your contributions is under [APACHE 2.0 License](https://github.com/mrtryhard/qt-ts-tools/blob/main/CONTRIBUTING.md) unless you specify otherwise.

