### PR TITLE
fixes #132: Add `keep-translation` to merge command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 This release improves on some missing functionality and functionalities defaults. Since it is breaking changes, 
 the version gets bumped to 0.7.0.
 
+### Added
+
+- Added `--keep-translation` flag to `merge` command to ensure to not override existing translations. 
+  Useful when you want to add new strings upon existing ones [#132](https://github.com/mrtryhard/qt-ts-tools/issues/132)
+
 ### Fixed
 
 - Fixed default output for `stat` command. Now defaults to short summary. Extended stats can be obtained with the `verbose` flag [#129](https://github.com/mrtryhard/qt-ts-tools/issues/129)
 - Fixed output for detailed report with very long file paths. The format takes more space but is more readable [#130](https://github.com/mrtryhard/qt-ts-tools/issues/130)
+
+### Changed
+
+- Removed dependency on `itertools` in [#132](https://github.com/mrtryhard/qt-ts-tools/issues/132)
 
 ## [0.6.0] - 2024-07-28
 [Eigth milestone](https://github.com/mrtryhard/qt-ts-tools/milestone/8).
@@ -22,7 +31,7 @@ This release makes the tool feature complete. The tool remains open for new feat
 
 - Added `stat` command line to query information about the input file [#111](https://github.com/mrtryhard/qt-ts-tools/issues/111)
 
-## Fixed
+### Fixed
 
 - Fixed reference to non-existing translation for `stat` command [#96](https://github.com/mrtryhard/qt-ts-tools/issues/96)
 - Executable size was 1.7MB in 0.5.1, 3.2MB during 0.6.0 development, now 1.2MB [#123](https://github.com/mrtryhard/qt-ts-tools/issues/123)
@@ -97,7 +106,7 @@ This release aims to make the executable even more robust, fix bugs and regressi
 ## [0.3.1] - 2024-05-12
 [Fourth milestone](https://github.com/mrtryhard/qt-ts-tools/milestone/5). Contains minor fixes to the command line tool.
 
-## Fixed
+### Fixed
 
 - Sorting now consider messages' id [#42](https://github.com/mrtryhard/qt-ts-tools/issues/42)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,12 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
 name = "env_filter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,15 +425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "qt-ts-tools"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -547,7 +532,6 @@ dependencies = [
  "fluent-bundle",
  "i18n-embed",
  "i18n-embed-fl",
- "itertools",
  "log",
  "quick-xml",
  "rust-embed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/mrtryhard/qt-ts-tools"
 keywords = ["qt", "translation", "windows", "linux"]
 homepage = "https://github.com/mrtryhard/qt-ts-tools"
 license = "MIT OR Apache-2.0"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Small command line utility to manipulate Qt's translation files with diverse operations."
 
@@ -20,7 +20,6 @@ env_logger = {  version = "0.11.5", default-features = false, features = ["human
 fluent-bundle = "0.15.3"
 i18n-embed = { version = "0.14.1", features = ["fluent-system"] }
 i18n-embed-fl = "0.8.0"
-itertools = "0.13.0"
 log = "0.4.22"
 quick-xml = { version = "0.36.1", features = ["serialize"] }
 rust-embed = "8.5.0"

--- a/resources/locales/en/qt_ts_tools.ftl
+++ b/resources/locales/en/qt_ts_tools.ftl
@@ -11,6 +11,7 @@ cli-help = Prints help information.
 cli-merge-desc = Merges two translation file contexts and messages into a single output.
 cli-merge-input-left = File to receive the merge.
 cli-merge-input-right = File to include changes from.
+cli-merge-keep-translation = When set, do not update translation in left file. This is used for adding new message nodes or context nodes.
 cli-merge-output = If specified, will produce output in a file at designated location instead of stdout.
 cli-shell-completion-desc = Prints a shell completion for supported shells.
 cli-shell-completion-install = When set, tries to install to default path or provided path (may require elevation).

--- a/resources/locales/fr/qt_ts_tools.ftl
+++ b/resources/locales/fr/qt_ts_tools.ftl
@@ -11,6 +11,7 @@ cli-help = Affiche l'aide.
 cli-merge-desc = Fusionne les contextes et message des deux fichiers de traductions spécifié en un seul.
 cli-merge-input-left = Fichier qui reçoit les changements.
 cli-merge-input-right = Fichier qui possède les changements.
+cli-merge-keep-translation = Lorsque spécifié, le merge ne met pas à jour les traductions dans le fichier de gauche. Utilisé pour ajouté les nouveaux noeuds "message" et "context".
 cli-merge-output = Si spécificé, chemin d'accès du fichier de sortie.
 cli-shell-completion-desc = Affiche le script d'auto-complétion pour un shell choisi.
 cli-shell-completion-install = Lorsque spécifié, l'outil tentera d'install le script d'auto-completion dans le chemin par défaut pour le shell, ou dans le path spécifié s'il y a lieu. Peut nécessiter une élévation de privilège.

--- a/test_data/example_merge_keep_translation_left.xml
+++ b/test_data/example_merge_keep_translation_left.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
+    <context>
+        <name>kernel/in_merge</name>
+        <message>
+            <id>idBasedLeft</id>
+            <source>Translation should not change</source>
+            <translation>La traduction ne devrait pas changer</translation>
+        </message>
+    </context>
+    <message>
+        <source>Simple translation</source>
+        <translation>Traduction simple</translation>
+    </message>
+</TS>

--- a/test_data/example_merge_keep_translation_result.xml
+++ b/test_data/example_merge_keep_translation_result.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
+  <context>
+    <name>kernel/in_merge</name>
+    <message>
+      <id>idBasedLeft</id>
+      <source>Translation should not change</source>
+      <translation>La traduction ne devrait pas changer</translation>
+    </message>
+    <message>
+      <id>newID</id>
+      <source>Should now be in merge.</source>
+      <translation type="unfinished"></translation>
+    </message>
+  </context>
+  <message>
+    <source>Simple translation</source>
+    <translation>Traduction simple</translation>
+  </message>
+  <message>
+    <source>Extra source</source>
+    <translation type="unfinished"></translation>
+  </message>
+</TS>

--- a/test_data/example_merge_keep_translation_right.xml
+++ b/test_data/example_merge_keep_translation_right.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
+    <context>
+        <name>kernel/in_merge</name>
+        <message>
+            <id>idBasedLeft</id>
+            <source>Translation should not change</source>
+            <translation type="unfinished"></translation>
+        </message>
+        <message>
+            <id>newID</id>
+            <source>Should now be in merge.</source>
+            <translation type="unfinished"></translation>
+        </message>
+    </context>
+    <message>
+        <source>Simple translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Extra source</source>
+        <translation type="unfinished"></translation>
+    </message>
+</TS>

--- a/test_data/example_merge_result.xml
+++ b/test_data/example_merge_result.xml
@@ -12,17 +12,17 @@
       <id>idBasedLeft</id>
     </message>
     <message>
+      <source>Newsletter</source>
+      <translation>
+        Nyhetsbrev - Right
+      </translation>
+    </message>
+    <message>
       <source>Only In Left Message</source>
       <translation>
         Only in Left translation
       </translation>
       <comment>Left message</comment>
-    </message>
-    <message>
-      <source>Newsletter</source>
-      <translation>
-        Nyhetsbrev - Right
-      </translation>
     </message>
     <message numerus="yes">
       <source>%1 takes at most %n argument(s). %2 is therefore invalid.</source>
@@ -57,6 +57,15 @@
     </message>
   </context>
   <message>
+    <source>Name</source>
+    <translation type="unfinished"/>
+    <location filename="ui_main.cpp" line="456"/>
+    <location filename="ui_potato_viewer.cpp" line="10"/>
+    <location filename="ui_main.cpp" line="321"/>
+    <location filename="ui_potato_viewer.cpp" line="11"/>
+    <comment>An example entry for Name</comment>
+  </message>
+  <message>
     <source>This is just a Sample</source>
     <translation>
       Dies ist nur ein Beispiel
@@ -70,15 +79,6 @@
   <message>
     <source>I am a message in which was written in Code</source>
     <translation/>
-  </message>
-  <message>
-    <source>Name</source>
-    <translation type="unfinished"/>
-    <location filename="ui_main.cpp" line="456"/>
-    <location filename="ui_potato_viewer.cpp" line="10"/>
-    <location filename="ui_main.cpp" line="321"/>
-    <location filename="ui_potato_viewer.cpp" line="11"/>
-    <comment>An example entry for Name</comment>
   </message>
   <message>
     <source>This is a new string</source>


### PR DESCRIPTION
This covers a specific use case where you want to add new strings on your translation file, but don't want to lose translations. This helps also updating locations.

### Pull request checklist

- [x] This pull request relates to an existing [issue ticket](https://github.com/mrtryhard/qt-ts-tools/issues). If not, create one.
- [x] [`CHANGELOG.md`](https://github.com/mrtryhard/qt-ts-tools/blob/main/CHANGELOG.md) is updated if relevant. 
- [x] You are aware that your contributions is under [APACHE 2.0 License](https://github.com/mrtryhard/qt-ts-tools/blob/main/CONTRIBUTING.md) unless you specify otherwise.