### PR TITLE
fixes #170: Update `quick-xml` to `0.37.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.7.1] - unreleased
+## [0.8.0] - unreleased
 [Tenth milestone](https://github.com/mrtryhard/qt-ts-tools/milestone/10).
-This release is a maintenance release with small dependencies update.
+This release contains breaking changes on the output produce by the tool. Otherwise, mostly dependencies upgrades.
 
 ### Fixed
 
@@ -21,6 +21,8 @@ This release is a maintenance release with small dependencies update.
 - Updated `i18n-embed-fl` to version `0.9.2`
 - Updated `serde` to version `1.0.214`
 - Updated `sys-locale` to version `0.3.2`
+- Breaking: Updated `quick-xml` to `0.37.0`, which effectively changes the output produced by the tool. 
+  The `translation` nodes now will have no indent.
 
 ## [0.7.0] - 2024-08-06
 [Ninth milestone](https://github.com/mrtryhard/qt-ts-tools/milestone/9).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "qt-ts-tools"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "ffbfb3ddf5364c9cfcd65549a1e7b801d0e8d1b14c1a1590a6408aa93cfbfa84"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/mrtryhard/qt-ts-tools"
 keywords = ["qt", "translation", "windows", "linux"]
 homepage = "https://github.com/mrtryhard/qt-ts-tools"
 license = "MIT OR Apache-2.0"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Small command line utility to manipulate Qt's translation files with diverse operations."
 
@@ -21,7 +21,7 @@ fluent-bundle = "0.15.3"
 i18n-embed = { version = "0.15.2", features = ["fluent-system"] }
 i18n-embed-fl = "0.9.2"
 log = "0.4.22"
-quick-xml = { version = "0.36.1", features = ["serialize"] }
+quick-xml = { version = "0.37.0", features = ["serialize"] }
 rust-embed = "8.5.0"
 serde = { version = "1.0.214", features = ["derive"] }
 sys-locale = "0.3.2"

--- a/test_data/example_extract_extracted.xml
+++ b/test_data/example_extract_extracted.xml
@@ -5,32 +5,24 @@
         <name>tst_QKeySequence</name>
         <message>
             <source>Shift+K</source>
-            <translation type="obsolete">
-                Umschalt+K
-            </translation>
+            <translation type="obsolete">Umschalt+K</translation>
             <location filename="tst_qkeysequence.cpp" line="369"></location>
         </message>
         <message>
             <source>Ctrl+K</source>
-            <translation type="obsolete">
-                Strg+K
-            </translation>
+            <translation type="obsolete">Strg+K</translation>
             <location filename="tst_qkeysequence.cpp" line="370"></location>
         </message>
         <message>
             <source>Alt+K</source>
-            <translation type="obsolete">
-                Alt+K
-            </translation>
+            <translation type="obsolete">Alt+K</translation>
             <location filename="tst_qkeysequence.cpp" line="150"></location>
             <location filename="tst_qkeysequence.cpp" line="371"></location>
         </message>
     </context>
     <message>
         <source>Shift+K</source>
-        <translation type="obsolete">
-            Umschalt+K
-        </translation>
+        <translation type="obsolete">Umschalt+K</translation>
         <location filename="tst_qkeysequence.cpp" line="369"></location>
     </message>
 </TS>

--- a/test_data/example_sort_sorted.xml
+++ b/test_data/example_sort_sorted.xml
@@ -12,9 +12,7 @@
         <name>UiContext</name>
         <message>
             <source>This is just a Sample</source>
-            <translation>
-                Dies ist nur ein Beispiel
-            </translation>
+            <translation>Dies ist nur ein Beispiel</translation>
             <location filename="ui_main.cpp" line="144"></location>
             <location filename="ui_potato_viewer.cpp" line="10"></location>
         </message>


### PR DESCRIPTION
Fixes #170.
This is a breaking change. The `$text` nodes will have their indent stripped in the output. For example:

```
<translation>
    some translation
</translation>
```

Will now become

```
<translation>some translation</translation>
```

### Pull request checklist

- [x] This pull request relates to an existing [issue ticket](https://github.com/mrtryhard/qt-ts-tools/issues). If not, create one.
- [x] [`CHANGELOG.md`](https://github.com/mrtryhard/qt-ts-tools/blob/main/CHANGELOG.md) is updated if relevant. 
- [x] You are aware that your contributions is under [APACHE 2.0 License](https://github.com/mrtryhard/qt-ts-tools/blob/main/CONTRIBUTING.md) unless you specify otherwise.
