### PR TITLE
fixes #212: Use Github Actions with their SHA.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Update Rust
         run: rustup update
       - name: Required tools
@@ -33,7 +33,7 @@ jobs:
       - name: Copy to ouput directory
         shell: bash
         run: mkdir -p output-win && cp target/release/qt-ts-tools.exe output-win/.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: binary-win-artifact
           path: output-win
@@ -42,7 +42,7 @@ jobs:
     name: Build Ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Update Rust
         run: rustup update
       - name: Required tools
@@ -61,7 +61,7 @@ jobs:
         run: cargo deny -L debug --all-features --locked check
       - name: Copy to ouput directory
         run: mkdir -p output-ub && cp target/release/qt-ts-tools output-ub/qt-ts-tools-linux
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: binary-ub-artifact
           path: output-ub
@@ -70,7 +70,7 @@ jobs:
     name: Build Ubuntu ARM
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Update Rust
         run: rustup update
       - name: Required tools
@@ -89,7 +89,7 @@ jobs:
         run: cargo deny -L debug --all-features --locked check
       - name: Copy to ouput directory
         run: mkdir -p output-ub-arm && cp target/release/qt-ts-tools output-ub-arm/qt-ts-tools-linux-arm
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: binary-ub-arm-artifact
           path: output-ub-arm
@@ -98,7 +98,7 @@ jobs:
     name: Build MacOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Update Rust
         run: rustup update
       - name: Required tools
@@ -117,7 +117,7 @@ jobs:
         run: cargo deny -L debug --all-features --locked check
       - name: Copy to ouput directory
         run: mkdir -p output-mac && cp target/release/qt-ts-tools output-mac/qt-ts-tools-macos
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # 4.6.2
         with:
           name: binary-mac-artifact
           path: output-mac
@@ -127,29 +127,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: [windows, ubuntu, ubuntu-arm, macos]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0
       - name: Get the release version from the tag
         shell: bash
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Retrieve Windows build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093　# 4.3.0
         with:
           name: binary-win-artifact
           path: output-win
       - name: Retrieve Mac build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093　# 4.3.0
         with:
           name: binary-mac-artifact
           path: output-mac
       - name: Retrieve Linux build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093　# 4.3.0
         with:
           name: binary-ub-artifact
           path: output-ub
       - name: Retrieve Linux Arm build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093　# 4.3.0
         with:
           name: binary-ub-arm-artifact
           path: output-ub-arm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Update Rust
         run: rustup update
       - name: Required tools

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
By using the Github Actions with their release tag, this exposes to a mutability vulnerability, where a release get retagged. By using the commit sha, this becomes immutable and ensure not bad actor inject code.

### Pull request checklist

- [x] This pull request relates to an existing [issue ticket](https://github.com/mrtryhard/qt-ts-tools/issues). If not, create one.
- [x] [`CHANGELOG.md`](https://github.com/mrtryhard/qt-ts-tools/blob/main/CHANGELOG.md) is updated if relevant. 
- [x] You are aware that your contributions is under [APACHE 2.0 License](https://github.com/mrtryhard/qt-ts-tools/blob/main/CONTRIBUTING.md) unless you specify otherwise.
- [x] This contribution is in accordance with the [Developer Certificate](https://developercertificate.org/)
