### PR TITLE
fixes #284: use commit hashes instead of tag number for RustSec audit-check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
       - name: Security audit
-        uses: rustsec/audit-check@v2.0.0
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # 2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: License check
@@ -54,7 +54,7 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
       - name: Security audit
-        uses: rustsec/audit-check@v2.0.0
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # 2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: License check
@@ -82,7 +82,7 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
       - name: Security audit
-        uses: rustsec/audit-check@v2.0.0
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # 2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: License check
@@ -110,7 +110,7 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
       - name: Security audit
-        uses: rustsec/audit-check@v2.0.0
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # 2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: License check

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # 2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Pull request checklist

- [x] This pull request relates to an existing [issue ticket](https://github.com/mrtryhard/qt-ts-tools/issues). If not, create one.
- [x] [`CHANGELOG.md`](https://github.com/mrtryhard/qt-ts-tools/blob/main/CHANGELOG.md) is updated if relevant. 
- [x] You are aware that your contributions is under [APACHE 2.0 License](https://github.com/mrtryhard/qt-ts-tools/blob/main/CONTRIBUTING.md) unless you specify otherwise.
- [x] This contribution is in accordance with the [Developer Certificate](https://developercertificate.org/)
